### PR TITLE
Move back from jsx-runtime

### DIFF
--- a/src/Scrollbars/defaultRenderElements.tsx
+++ b/src/Scrollbars/defaultRenderElements.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes } from 'react';
+import React, { HTMLAttributes } from 'react';
 
 export function renderViewDefault(props: HTMLAttributes<HTMLDivElement>) {
   return <div {...props} />;

--- a/src/Scrollbars/index.tsx
+++ b/src/Scrollbars/index.tsx
@@ -1,7 +1,6 @@
-import * as React from 'react';
+import React, { Component, createElement, cloneElement, HTMLAttributes } from 'react';
 import raf, { cancel as caf } from 'raf';
 import css from 'dom-css';
-import { Component, createElement, cloneElement, HTMLAttributes } from 'react';
 import { ScrollValues } from './types';
 
 import getScrollbarWidth from '../utils/getScrollbarWidth';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
       "esnext"
     ],
     "allowJs": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "declaration": true,
     "outDir": "lib",
     "removeComments": true,


### PR DESCRIPTION
For fully backward compatibility, have to move to preserve mode of jsx in typescript. 