### PR TITLE
Add an optional rootElementProps prop

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -18,6 +18,7 @@ order: 4
 | className | className for the root component | `string` | `undefined`
 | disableDefaultStyles | removes basic styling to ease visual customization | `boolean` | `false` 
 | hideTracksWhenNotNeeded | Hide tracks (`visibility: hidden`) when content does not overflow container. | `boolean` | `false` |
+| id | The `id` to apply to the root element | `string` | `undefined` |
 | onScroll | Event handler | `(e: React.UIEvent<HTMLElement>) => void` | `undefined` |
 | onScrollFrame | Runs inside the animation frame. Type of `ScrollValues` you can check below | `(values: ScrollValues) => void` | `undefined` |
 | onScrollStart | Called when scrolling starts | `() => void` | `undefined` |

--- a/src/Scrollbars/types.ts
+++ b/src/Scrollbars/types.ts
@@ -13,6 +13,7 @@ export interface ScrollbarsProps {
   classes?: Partial<StyleClasses>;
   disableDefaultStyles: boolean;
   hideTracksWhenNotNeeded?: boolean;
+  id?: string;
   onScroll?: (e: React.UIEvent<HTMLElement>) => void;
   onScrollFrame?: (values: ScrollValues) => void;
   onScrollStart?: () => void;

--- a/test/Scrollbars/rendering.js
+++ b/test/Scrollbars/rendering.js
@@ -27,6 +27,19 @@ export default function createTests(scrollbarWidth) {
         );
       });
 
+      it('takes id', (done) => {
+        render(
+          <Scrollbars id="foo">
+            <div style={{ width: 200, height: 200 }} />
+          </Scrollbars>,
+          node,
+          function callback() {
+            expect(findDOMNode(this).id).toEqual('foo');
+            done();
+          },
+        );
+      });
+
       it('takes styles', (done) => {
         render(
           <Scrollbars style={{ width: 100, height: 100 }}>


### PR DESCRIPTION
This PR aims to add support for props that are assigned to the root element.

In my particular case, I would need to add support for the `id` property. My use-case is that I use the Intersection Observer API to measure the offset relative to some parent, and the parent is identified using the `id` property. In practice, this is used to lazily load content (for example images) within a scrollable container, which is a fairly common use-case.

The `prepublish` and `build:docs` scripts run just fine but I wasn't able to run the tests locally, seemingly because of issues with the webpack configuration. If I can get some pointers on that, I'll happily add a few test cases as well.

This is the output I get when attempting to run the tests:

```
 rc-scrollbars git:(support-htmldivelement-props) ✗ yarn test                
yarn run v1.22.4
$ cross-env NODE_ENV=test karma start
WebpackOptionsValidationError: Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.module has an unknown property 'loaders'. These properties are valid:
   object { exprContextCritical?, exprContextRecursive?, exprContextRegExp?, exprContextRequest?, noParse?, rules?, defaultRules?, unknownContextCritical?, unknownContextRecursive?, unknownContextRegExp?, unknownContextRequest?, unsafeCache?, wrappedContextCritical?, wrappedContextRecursive?, wrappedContextRegExp?, strictExportPresence?, strictThisContextOnImports? }
   -> Options affecting the normal modules (`NormalModuleFactory`).
    at webpack (/Users/zakke/sources/mafy/rc-scrollbars/node_modules/webpack/lib/webpack.js:23:9)
    at Plugin (/Users/zakke/sources/mafy/rc-scrollbars/node_modules/karma-webpack/dist/karma-webpack.js:128:16)
    at invoke (/Users/zakke/sources/mafy/rc-scrollbars/node_modules/di/lib/injector.js:75:15)
    at Array.instantiate (/Users/zakke/sources/mafy/rc-scrollbars/node_modules/di/lib/injector.js:59:20)
    at get (/Users/zakke/sources/mafy/rc-scrollbars/node_modules/di/lib/injector.js:48:43)
    at /Users/zakke/sources/mafy/rc-scrollbars/node_modules/di/lib/injector.js:71:14
    at Array.map (<anonymous>)
    at Array.invoke (/Users/zakke/sources/mafy/rc-scrollbars/node_modules/di/lib/injector.js:70:31)
    at Injector.get (/Users/zakke/sources/mafy/rc-scrollbars/node_modules/di/lib/injector.js:48:43)
    at instantiatePreprocessor (/Users/zakke/sources/mafy/rc-scrollbars/node_modules/karma/lib/preprocessor.js:84:20)
25 02 2021 11:00:42.442:ERROR [preprocess]: Can not load "webpack"!
  WebpackOptionsValidationError: Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.module has an unknown property 'loaders'. These properties are valid:
   object { exprContextCritical?, exprContextRecursive?, exprContextRegExp?, exprContextRequest?, noParse?, rules?, defaultRules?, unknownContextCritical?, unknownContextRecursive?, unknownContextRegExp?, unknownContextRequest?, unsafeCache?, wrappedContextCritical?, wrappedContextRecursive?, wrappedContextRegExp?, strictExportPresence?, strictThisContextOnImports? }
   -> Options affecting the normal modules (`NormalModuleFactory`).
    at webpack (/Users/zakke/sources/mafy/rc-scrollbars/node_modules/webpack/lib/webpack.js:23:9)
    at Plugin (/Users/zakke/sources/mafy/rc-scrollbars/node_modules/karma-webpack/dist/karma-webpack.js:128:16)
    at invoke (/Users/zakke/sources/mafy/rc-scrollbars/node_modules/di/lib/injector.js:75:15)
    at Array.instantiate (/Users/zakke/sources/mafy/rc-scrollbars/node_modules/di/lib/injector.js:59:20)
    at get (/Users/zakke/sources/mafy/rc-scrollbars/node_modules/di/lib/injector.js:48:43)
    at /Users/zakke/sources/mafy/rc-scrollbars/node_modules/di/lib/injector.js:71:14
    at Array.map (<anonymous>)
    at Array.invoke (/Users/zakke/sources/mafy/rc-scrollbars/node_modules/di/lib/injector.js:70:31)
    at Injector.get (/Users/zakke/sources/mafy/rc-scrollbars/node_modules/di/lib/injector.js:48:43)
    at instantiatePreprocessor (/Users/zakke/sources/mafy/rc-scrollbars/node_modules/karma/lib/preprocessor.js:84:20)

START:
25 02 2021 11:00:42.476:ERROR [karma-server]: Error during file loading or preprocessing
TypeError: process is not a function
    at executeProcessor (/Users/zakke/sources/mafy/rc-scrollbars/node_modules/karma/lib/preprocessor.js:47:11)
    at runProcessors (/Users/zakke/sources/mafy/rc-scrollbars/node_modules/karma/lib/preprocessor.js:60:23)
    at FileList.preprocess [as _preprocess] (/Users/zakke/sources/mafy/rc-scrollbars/node_modules/karma/lib/preprocessor.js:134:11)
25 02 2021 11:00:42.477:INFO [karma-server]: Karma v5.2.3 server started at http://localhost:9876/
25 02 2021 11:00:42.477:INFO [launcher]: Launching browsers Chrome with concurrency unlimited
25 02 2021 11:00:42.478:ERROR [karma-server]: Error: Found 1 load error
    at Server.webServer.listen (/Users/zakke/sources/mafy/rc-scrollbars/node_modules/karma/lib/server.js:213:27)
    at Object.onceWrapper (events.js:286:20)
    at Server.emit (events.js:203:15)
    at emitListeningNT (net.js:1314:10)
    at process._tickCallback (internal/process/next_tick.js:63:19)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```