### PR TITLE
Update pxRatio after calculating scrollbar width

### DIFF
--- a/src/utils/getScrollbarWidth.ts
+++ b/src/utils/getScrollbarWidth.ts
@@ -11,6 +11,7 @@ export default function getScrollbarWidth() {
 
   if (pxRatio !== newPxRatio) {
     scrollbarWidth = getScrollbarWidthFromDom();
+    pxRatio = newPxRatio;
   }
 
   if (typeof scrollbarWidth === 'number') return scrollbarWidth;


### PR DESCRIPTION
Without this, the `newPxRatio === pxRatio` check was ineffective, so we were recalculating the scrollbar width from DOM everytime. This causes an element to be needlessly added and removed to the DOM on every re-render.